### PR TITLE
added description field to CatalogEntry and get description key/value…

### DIFF
--- a/src/NuGet.CatalogReader/CatalogEntry.cs
+++ b/src/NuGet.CatalogReader/CatalogEntry.cs
@@ -23,6 +23,7 @@ namespace NuGet.CatalogReader
             string commitId,
             DateTimeOffset commitTs,
             string id,
+            string description,
             NuGetVersion version,
             ServiceIndexResourceV3 serviceIndex,
             Func<Uri, CancellationToken, Task<JObject>> getJson,
@@ -34,6 +35,7 @@ namespace NuGet.CatalogReader
             Types = new List<string>() { type };
             CommitId = commitId;
             CommitTimeStamp = commitTs;
+            Description = description;
         }
 
         /// <summary>
@@ -85,6 +87,11 @@ namespace NuGet.CatalogReader
         public DateTimeOffset CommitTimeStamp { get; }
 
         /// <summary>
+        /// description of the catalog entry
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
         /// Read the Uri into a JObject. This contains all package details.
         /// </summary>
         public Task<JObject> GetPackageDetailsAsync()
@@ -99,7 +106,7 @@ namespace NuGet.CatalogReader
         {
             return _getJson(Uri, token);
         }
-        
+
         /// <summary>
         /// Compare by date.
         /// </summary>

--- a/src/NuGet.CatalogReader/CatalogReader.cs
+++ b/src/NuGet.CatalogReader/CatalogReader.cs
@@ -133,7 +133,7 @@ namespace NuGet.CatalogReader
                 if (entry.IsDelete)
                 {
                     // Mark as deleted, this has no
-                    // impact if the package was re-added. It will 
+                    // impact if the package was re-added. It will
                     // already be in the set in that case.
                     deleted.Add(entry);
                 }
@@ -246,7 +246,7 @@ namespace NuGet.CatalogReader
              * Suppose the following numbers represent the commit timestamps of ten packages published.
              * Also suppose that each timestamp is distinct, for simplicity. Finally, assume page size in the
              * catalog is two. The resulting five pages (identified by P0 .. P4) are:
-             * 
+             *
              *   0  1  2  3  4  5  6  7  8  9
              *   \__/  \__/  \__/  \__/  \__/
              *    P0    P1    P2    P3    P4
@@ -350,6 +350,7 @@ namespace NuGet.CatalogReader
                         cache.GetString(item["commitId"].ToObject<string>()),
                         cache.GetDate(item["commitTimeStamp"].ToObject<string>()),
                         cache.GetString(item["nuget:id"].ToObject<string>()),
+                        cache.GetString(item["nuget:description"].ToObject<string>()),
                         cache.GetVersion(item["nuget:version"].ToObject<string>()),
                         _serviceIndex,
                         GetJson,


### PR DESCRIPTION
… from response data in CatalogReader

Hi, I'm on the Powershell team and working on a wildcard search functionality compatible with V3 Protocol endpoints (i.e searching for packages from a gallery like NuGet gallery that has v3 endpoint: https://api.nuget.org/v3/index.json). Eventually we'll adopt a V3 protocol for PSGallery and want to be able to search for packages with that V3 endpoint.

I'm using this NuGet.CatalogReader library to get all packages, filter for the ones I want, and then display information to the user regarding the package. Specifically, I would like to display the name, version, description of the latest version of the package. With your current code, I'm able to get the first two (through the `id` and `version` field of CatalogEntry which inherits from PackageEntry). I'm creating this PR to get the description field from the `items` response data when the `id` and `version` fields are being saved too.