### PR TITLE
Locally configured source support

### DIFF
--- a/src/NuGetMirror/NupkgsCommand.cs
+++ b/src/NuGetMirror/NupkgsCommand.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using NuGet.CatalogReader;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -45,7 +46,7 @@ namespace NuGetMirror
 
             var argRoot = cmd.Argument(
                 "[root]",
-                "V3 feed index.json URI",
+                "V3 feed index.json URI or a locally configured source name",
                 multipleValues: false);
 
             cmd.HelpOption(Constants.HelpOption);
@@ -57,14 +58,32 @@ namespace NuGetMirror
 
                 if (string.IsNullOrEmpty(argRoot.Value))
                 {
-                    throw new ArgumentException("Provide the full http url to a v3 nuget feed.");
+                    throw new ArgumentException("Provide the full http url to a v3 nuget feed or a locally configured source name.");
                 }
 
-                var index = new Uri(argRoot.Value);
-
-                if (!index.AbsolutePath.EndsWith("/index.json", StringComparison.OrdinalIgnoreCase))
+                // Attempts to load a configured source (including inactive ones) and fallback to Uri parsing if it fails
+                Uri index;
+                var sources = PackageSourceProvider.LoadPackageSources(Settings.LoadDefaultSettings(Environment.CurrentDirectory));
+                var source = sources.FirstOrDefault(o => o.Name == argRoot.Value);
+                if (source != null)
                 {
-                    throw new ArgumentException($"Invalid feed url: '{argRoot.Value}'. Provide the full http url to a v3 nuget feed. For nuget.org use: https://api.nuget.org/v3/index.json");
+                    index = source.SourceUri;
+                    httpSource = HttpSource.Create(Repository.Factory.GetCoreV3(source));
+                }
+                else
+                {
+                    if (!Uri.TryCreate(argRoot.Value, UriKind.Absolute, out index))
+                    {
+                        // The enumerable is safe to re-iterate because it's a List implementation
+                        Debug.Assert(sources is ICollection<PackageSource>, "Sources implementation changed");
+                        var sourceNames = string.Join(", ", sources.Select(o => o.Name));
+                        throw new ArgumentException($"Invalid feed identifier: '{argRoot.Value}'. Provide the full http url to a v3 nuget feed or a locally configured identifier. Configured sources are: {sourceNames}");
+                    }
+
+                    if (!index.AbsolutePath.EndsWith("/index.json", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new ArgumentException($"Invalid feed url: '{argRoot.Value}'. Provide the full http url to a v3 nuget feed. For nuget.org use: https://api.nuget.org/v3/index.json");
+                    }
                 }
 
                 // Create root


### PR DESCRIPTION
I needed support for source authentication so I added support for loading locally configured sources for NuGetMirror's list and nupkgs commands.

Documentation might need updating if the changes get merged.