### PR TITLE
Fix SourceCacheContext initialization

### DIFF
--- a/src/NuGet.CatalogReader/Common/TaskUtils.cs
+++ b/src/NuGet.CatalogReader/Common/TaskUtils.cs
@@ -39,7 +39,7 @@ namespace NuGet.CatalogReader
         {
             return RunAsync(
                 tasks: tasks.Select(GetFuncWithReturnValue),
-                useTaskRun: false,
+                useTaskRun: useTaskRun,
                 token: token);
         }
 
@@ -50,7 +50,7 @@ namespace NuGet.CatalogReader
         {
             return RunAsync(
                 tasks: tasks.Select(GetFuncWithReturnValue),
-                useTaskRun: false,
+                useTaskRun: useTaskRun,
                 maxThreads: maxThreads,
                 token: token);
         }

--- a/src/NuGet.CatalogReader/ProcessEntriesUtility.cs
+++ b/src/NuGet.CatalogReader/ProcessEntriesUtility.cs
@@ -29,7 +29,7 @@ namespace NuGet.CatalogReader
         {
             var entriesArray = entries.ToArray();
 
-            if (entries.Distinct().Count() != entriesArray.Length)
+            if (entriesArray.Distinct().Count() != entriesArray.Length)
             {
                 throw new InvalidOperationException("Duplicate entries detected. Entries must be unique by id/version.");
             }
@@ -63,7 +63,7 @@ namespace NuGet.CatalogReader
         {
             var entriesArray = entries.ToArray();
 
-            maxThreads = Math.Min(1, maxThreads);
+            maxThreads = Math.Max(1, maxThreads);
 
             var files = new List<T>(entriesArray.Length);
             var tasks = new List<Task<T>>(maxThreads);

--- a/src/NuGetMirror/Common/TaskUtils.cs
+++ b/src/NuGetMirror/Common/TaskUtils.cs
@@ -39,7 +39,7 @@ namespace NuGetMirror
         {
             return RunAsync(
                 tasks: tasks.Select(GetFuncWithReturnValue),
-                useTaskRun: false,
+                useTaskRun: useTaskRun,
                 token: token);
         }
 
@@ -50,7 +50,7 @@ namespace NuGetMirror
         {
             return RunAsync(
                 tasks: tasks.Select(GetFuncWithReturnValue),
-                useTaskRun: false,
+                useTaskRun: useTaskRun,
                 maxThreads: maxThreads,
                 token: token);
         }


### PR DESCRIPTION
## Summary
- ensure HttpReaderBase creates a SourceCacheContext when cacheContext is null
- fix thread count init in ProcessEntriesUtility
- use message handler overload correctly
- honor `useTaskRun` in TaskUtils

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*